### PR TITLE
Add support for Services synchronization

### DIFF
--- a/clients/directory_client.py
+++ b/clients/directory_client.py
@@ -13,6 +13,11 @@ def get_all_biobanks():
                     {   id
                         name
                         withdrawn
+                        services {
+                          id 
+                          name 
+                          description
+                        }
                     }
   
             }
@@ -65,3 +70,31 @@ def get_all_directory_networks():
     '''
     results = requests.post(DIRECTORY_API_URL, json={'query': emx2_networks_query}).json()
     return NetworkDirectoryDTO.parse(results['data']['Networks'])
+
+
+def get_all_directory_services(biobanks: list[OrganizationDirectoryDTO]):
+    parsed_services = list()
+    emx2_services_query = '''
+    query {
+        Services
+            {   id
+                name
+                description
+                    
+            }  
+    }       
+    '''
+    results = requests.post(DIRECTORY_API_URL, json={'query': emx2_services_query}).json()
+    for service in results['data']['Services']:
+        service_biobank = get_biobank_by_service(biobanks, service['id'])
+        service_resource_directory = ResourceDirectoryDTO(id=service['id'], name=service['name'],
+                                                          description=service['description'], biobank=service_biobank)
+        parsed_services.append(service_resource_directory)
+    return parsed_services
+
+
+def get_biobank_by_service(biobanks: list[OrganizationDirectoryDTO], service_id):
+    for b in biobanks:
+        for service in b.services:
+            if service.id == service.id:
+                return b

--- a/clients/directory_client.py
+++ b/clients/directory_client.py
@@ -1,13 +1,14 @@
 import requests
 
-from config import DIRECTORY_API_URL
+from config import DIRECTORY_API_URL, CHECK_SERVICES_SUPPORT
 from models.dto.network import NetworkDirectoryDTO
 from models.dto.organization import OrganizationDirectoryDTO
 from models.dto.resource import ResourceDirectoryDTO
 
 
-def get_all_biobanks():
-    emx2_biobanks_query = '''
+def get_emx2_biobank_query():
+    if CHECK_SERVICES_SUPPORT:
+        return '''
     query {
                 Biobanks
                     {   id
@@ -22,6 +23,19 @@ def get_all_biobanks():
   
             }
     '''
+    return '''
+    query {
+                Biobanks
+                    {   id
+                        name
+                        withdrawn
+                    }
+            }
+    '''
+
+
+def get_all_biobanks():
+    emx2_biobanks_query = get_emx2_biobank_query()
     results = requests.post(DIRECTORY_API_URL, json={'query': emx2_biobanks_query}).json()
     return OrganizationDirectoryDTO.parse(results['data']['Biobanks'])
 
@@ -74,6 +88,8 @@ def get_all_directory_networks():
 
 def get_all_directory_services(biobanks: list[OrganizationDirectoryDTO]):
     parsed_services = list()
+    if not CHECK_SERVICES_SUPPORT:
+        return []
     emx2_services_query = '''
     query {
         Services

--- a/compose/docker-compose-integration-tests.yml
+++ b/compose/docker-compose-integration-tests.yml
@@ -79,7 +79,7 @@ services:
     networks:
       - directory-negotiator-sync-test
   emx2:
-    image: molgenis/molgenis-emx2-snapshot
+    image: molgenis/molgenis-emx2:v11.34.0
     environment:
       - TZ=Europe/Rome
       - MOLGENIS_POSTGRES_URI=jdbc:postgresql://postgres:5432/molgenis

--- a/compose/docker-compose-integration-tests.yml
+++ b/compose/docker-compose-integration-tests.yml
@@ -79,7 +79,7 @@ services:
     networks:
       - directory-negotiator-sync-test
   emx2:
-    image: molgenis/molgenis-emx2:latest
+    image: molgenis/molgenis-emx2-snapshot
     environment:
       - TZ=Europe/Rome
       - MOLGENIS_POSTGRES_URI=jdbc:postgresql://postgres:5432/molgenis

--- a/config.py
+++ b/config.py
@@ -1,7 +1,10 @@
 import logging
 import os
 
-DIRECTORY_API_URL = os.getenv('DIRECTORY_EMX2_ENDPOINT', 'https://directory-emx2-acc.molgenis.net/ERIC/directory/graphql')
+import requests
+
+DIRECTORY_API_URL = os.getenv('DIRECTORY_EMX2_ENDPOINT',
+                              'https://directory-emx2-acc.molgenis.net/ERIC/directory/graphql')
 NEGOTIATOR_API_URL = os.getenv('NEGOTIATOR_ENDPOINT', 'http://localhost:8081/api/v3')
 AUTH_CLIENT_ID = os.getenv('NEGOTIATOR_CLIENT_AUTH_CLIENT_ID', '123')
 AUTH_CLIENT_SECRET = os.getenv('NEGOTIATOR_CLIENT_AUTH_CLIENT_SECRET', '123')
@@ -30,4 +33,24 @@ def setup_logger(log_level=logging.INFO):
     return logger
 
 
+def check_services_support():
+    query = '''
+    query {
+            Biobanks
+            {   services {
+                          id 
+                          name 
+                          description
+                        }
+                }
+
+            }
+    '''
+    results = requests.post(DIRECTORY_API_URL, json={'query': query})
+    if results.status_code == 200:
+        return True
+    return False
+
+
 LOG = setup_logger(logging.DEBUG)
+CHECK_SERVICES_SUPPORT = check_services_support()

--- a/models/dto/organization.py
+++ b/models/dto/organization.py
@@ -1,10 +1,19 @@
+from typing import Optional
+
 from pydantic import BaseModel, Field, ConfigDict
+
+
+class ServiceDirectoryDTO(BaseModel):
+    id: str
+    name: str
+    description: Optional[str]
 
 
 class OrganizationDirectoryDTO(BaseModel):
     id: str = Field(..., alias='externalId')
     name: str
     withdrawn: bool = Field(default=False)
+    services: Optional[list[ServiceDirectoryDTO]] = Field(default=[])
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -13,7 +22,8 @@ class OrganizationDirectoryDTO(BaseModel):
     @staticmethod
     def parse(directory_data):
         return [OrganizationDirectoryDTO(id=organization.get('id'), name=organization.get('name'),
-                                         withdrawn=organization.get('withdrawn')) for
+                                         withdrawn=organization.get('withdrawn'), services=organization.get('services'))
+                for
                 organization in directory_data]
 
 

--- a/synchronization/sync_service.py
+++ b/synchronization/sync_service.py
@@ -1,5 +1,6 @@
 from auth import renew_access_token
-from clients.directory_client import (get_all_biobanks, get_all_collections, get_all_directory_networks)
+from clients.directory_client import (get_all_biobanks, get_all_collections, get_all_directory_networks,
+                                      get_all_directory_services)
 from clients.negotiator_client import resource_create_dto, network_create_dto, NegotiatorAPIClient, \
     get_resource_id_by_source_id
 from config import LOG
@@ -46,7 +47,7 @@ def sync_all(negotiator_client: NegotiatorAPIClient):
     job_id = (negotiator_client.add_sync_job()).json()['id']
     directory_organizations = get_all_biobanks()
     negotiator_organizations = negotiator_client.get_all_organizations()
-    directory_resources = get_all_collections()
+    directory_resources = get_all_collections() + get_all_directory_services(directory_organizations)
     sync_organizations(negotiator_client, directory_organizations, negotiator_organizations)
     directory_network_resources_links = get_all_directory_resources_networks_links(directory_resources)
     negotiator_resources = negotiator_client.get_all_resources()
@@ -107,7 +108,6 @@ def sync_resources(negotiator_client: NegotiatorAPIClient, directory_resources: 
                                                                       directory_resource.description)
     if len(resources_to_add) > 0:
         negotiator_client.add_resources(resources_to_add)
-
 
 
 @renew_access_token

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -32,7 +32,10 @@ def add_or_update_biobank(biobank_id, biobank_pid, biobank_name, biobank_descrip
                 "national_node": {
                     "id": "NL",
                     "description": "Netherlands"
-                }
+                },
+                'services': [
+                    {'id': 'bbmri-eric:serviceID:DE_1234'}
+                ]
             }
         ]
     }
@@ -190,3 +193,31 @@ def get_negotiator_network_id_by_external_id(external_id, negotiator_networks: [
     for n in negotiator_networks:
         if n.externalId == external_id:
             return n.id
+
+
+def add_or_update_service(service_id, service_name, service_description, operation=Literal['insert', 'update']):
+    session = pytest.directory_session
+    query = f'mutation {operation}($value:[ServicesInput]){{{operation}(Services:$value){{message}}}}'
+    service = {
+        'id': service_id,
+        'name': service_name,
+        'description': service_description,
+        "serviceTypes": [
+            {"name": "PET-Scans",
+             "label": "PET Scans",
+             "serviceCategory": {
+                 "name": "imagingServices", "label": "Imaging Services"
+             }
+             }
+        ],
+        "accessDescription": "https://biobank2-service-access.nl",
+        "national_node": {"id": "NL", "description": "Netherlands", "dns": "https://external_server.nl"},
+    }
+    variables = {
+        "value": [service]
+    }
+    response = session.post(DIRECTORY_API_URL, json={'query': query, 'variables': variables},
+                            auth=HTTPBasicAuth('admin', 'admin'))
+    if response.status_code != 200:
+        raise Exception(
+            f'Impossible to complete the test, erroor when adding the new Service. Status code: {response.status_code} . Error: {response.text}')


### PR DESCRIPTION
This PR implements https://github.com/BBMRI-ERIC/directory-negotiator-sync/issues/6. 
Services are read from the Directory and saved into the Negotiator as resources. An initial check is performed for Services implementation in the input EMX2 directory, for retro compatibility. 