### PR TITLE
Add more attributes to sync for Directory Resources 

### DIFF
--- a/clients/directory_client.py
+++ b/clients/directory_client.py
@@ -13,7 +13,13 @@ def get_emx2_biobank_query():
                 Biobanks
                     {   id
                         name
+                        description
+                        url
                         withdrawn
+                        contact
+                        {
+                        email
+                        }    
                         services {
                           id 
                           name 
@@ -28,6 +34,12 @@ def get_emx2_biobank_query():
                 Biobanks
                     {   id
                         name
+                        description
+                        contact
+                        {
+                        email
+                        }
+                        url
                         withdrawn
                     }
             }
@@ -47,19 +59,31 @@ def get_all_collections():
             {   id
                 name
                 description
+                contact
+                        {
+                        email
+                        }
+                url
                 biobank {
                     id
                     name
+                    description
+                    contact
+                        {
+                        email
+                        }
+                        url                   
                 }
                 network {   
                     id
                     name
+                    description
                     url
                     contact
                         {
                         email
                         }
-                    }
+                }
                 }  
     }
     
@@ -74,6 +98,7 @@ def get_all_directory_networks():
         Networks
             {   id
                 name
+                description
                 url
                 contact
                     {
@@ -96,7 +121,9 @@ def get_all_directory_services(biobanks: list[OrganizationDirectoryDTO]):
             {   id
                 name
                 description
-                    
+                contactInformation {
+                    email
+                }             
             }  
     }       
     '''
@@ -104,7 +131,9 @@ def get_all_directory_services(biobanks: list[OrganizationDirectoryDTO]):
     for service in results['data']['Services']:
         service_biobank = get_biobank_by_service(biobanks, service['id'])
         service_resource_directory = ResourceDirectoryDTO(id=service['id'], name=service['name'],
-                                                          description=service['description'], biobank=service_biobank)
+                                                          description=service['description'], biobank=service_biobank,
+                                                          contactEmail=service['contactInformation'][
+                                                              'email'] if 'contactInformation' in service else '')
         parsed_services.append(service_resource_directory)
     return parsed_services
 

--- a/clients/negotiator_client.py
+++ b/clients/negotiator_client.py
@@ -70,16 +70,19 @@ class NegotiatorAPIClient:
     def add_organizations(self, organizations: list[OrganizationDirectoryDTO]):
         self.post('organizations', data=json.dumps(organizations))
 
-    def update_organization_name(self, id, name, external_id):
-        self.put(f'organizations/{id}', data=json.dumps({'name': name, 'externalId': external_id}))
+    def update_organization_info(self, id, name, external_id, description, contact_email, uri):
+        self.put(f'organizations/{id}', data=json.dumps({'name': name, 'externalId': external_id,
+                                                         'description': description, 'contactEmail': contact_email,
+                                                         'uri': uri}))
 
     def add_resources(self, resources: list):
         added_resources = self.post('resources', data=json.dumps(resources))
         return added_resources.json()
 
-    def update_resource_name_or_description(self, id, name, description):
+    def update_resource_data(self, id, name, description, contact_email, uri):
         self.patch(f'resources/{id}',
-                   data=json.dumps({'name': name, 'description': description}))
+                   data=json.dumps(
+                       {'name': name, 'description': description, 'contactEmail': contact_email, 'uri': uri}))
 
     def add_networks(self, networks: list):
         added_networks = self.post('networks', data=json.dumps(networks))
@@ -101,9 +104,10 @@ class NegotiatorAPIClient:
         except KeyError:
             return []
 
-    def update_network_info(self, id, name, url, email, external_id):
+    def update_network_info(self, id, name, description, url, email, external_id):
         self.put(f'networks/{id}',
-                 data=json.dumps({'name': name, 'uri': url, 'contactEmail': email, 'externalId': external_id}))
+                 data=json.dumps({'name': name, 'description': description, 'uri': url, 'contactEmail': email,
+                                  'externalId': external_id}))
 
     def add_sync_job(self):
         return self.post('discovery-services/1/sync-jobs')

--- a/models/dto/network.py
+++ b/models/dto/network.py
@@ -24,8 +24,8 @@ class NegotiatorNetworkDTO(BaseModel):
     externalId: str
     name: str
     description: Optional[str] = Field(default='')
-    contactEmail: str
-    uri: str
+    contactEmail: Optional[str] = Field(default='')
+    uri: Optional[str] = Field(default='')
 
     @staticmethod
     def parse(negotiator_data):

--- a/models/dto/network.py
+++ b/models/dto/network.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class Contact(BaseModel):
@@ -10,6 +10,7 @@ class Contact(BaseModel):
 class NetworkDirectoryDTO(BaseModel):
     id: str
     name: str
+    description: str
     url: Optional[str] = ''
     contact: Contact
 
@@ -22,6 +23,7 @@ class NegotiatorNetworkDTO(BaseModel):
     id: int
     externalId: str
     name: str
+    description: Optional[str] = Field(default='')
     contactEmail: str
     uri: str
 

--- a/models/dto/organization.py
+++ b/models/dto/organization.py
@@ -3,6 +3,10 @@ from typing import Optional
 from pydantic import BaseModel, Field, ConfigDict
 
 
+class Contact(BaseModel):
+    email: str
+
+
 class ServiceDirectoryDTO(BaseModel):
     id: str
     name: str
@@ -12,6 +16,9 @@ class ServiceDirectoryDTO(BaseModel):
 class OrganizationDirectoryDTO(BaseModel):
     id: str = Field(..., alias='externalId')
     name: str
+    description: str
+    contact: Contact
+    url: Optional[str] = Field(default='')
     withdrawn: bool = Field(default=False)
     services: Optional[list[ServiceDirectoryDTO]] = Field(default=[])
 
@@ -22,6 +29,9 @@ class OrganizationDirectoryDTO(BaseModel):
     @staticmethod
     def parse(directory_data):
         return [OrganizationDirectoryDTO(id=organization.get('id'), name=organization.get('name'),
+                                         description=organization.get('description'),
+                                         contact=organization.get('contact'),
+                                         url=organization.get('url') if 'url' in organization else '',
                                          withdrawn=organization.get('withdrawn'), services=organization.get('services'))
                 for
                 organization in directory_data]
@@ -31,6 +41,9 @@ class NegotiatorOrganizationDTO(BaseModel):
     id: int
     externalId: str
     name: str
+    description: Optional[str] = Field(default='')
+    contactEmail: Optional[str] = Field(default='')
+    uri: Optional[str] = Field(default='')
 
     @staticmethod
     def parse(negotiator_data):

--- a/models/dto/resource.py
+++ b/models/dto/resource.py
@@ -1,15 +1,21 @@
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from .network import NetworkDirectoryDTO
 from ..dto.organization import OrganizationDirectoryDTO
+
+
+class Contact(BaseModel):
+    email: str
 
 
 class ResourceDirectoryDTO(BaseModel):
     id: str
     name: str
     description: Optional[str]
+    contact: Optional[Contact] = Field(default=None)
+    url: Optional[str] = Field(default='')
     biobank: OrganizationDirectoryDTO
     network: Optional[list[NetworkDirectoryDTO]] = None
 
@@ -22,7 +28,9 @@ class NegotiatorResourceDTO(BaseModel):
     id: int
     sourceId: str
     name: str
-    description: Optional[str]
+    description: Optional[str] = Field(default='')
+    contactEmail: Optional[str] = Field(default='')
+    uri: Optional[str] = Field(default='')
 
     @staticmethod
     def parse(negotiator_data):

--- a/synchronization/sync_service.py
+++ b/synchronization/sync_service.py
@@ -76,8 +76,10 @@ def sync_organizations(negotiator_client: NegotiatorAPIClient, directory_organzi
                     f'Updating name and/or description and/or contact email and/or uri for organization: {external_id}')
                 LOG.info(f'Current organization name is: {negotiation_organization.name}')
                 LOG.info(f'New organization name is: {directory_organization.name}')
-                negotiator_client.update_organization_name(negotiation_organization.id, directory_organization.name,
-                                                           external_id)
+                negotiator_client.update_organization_info(negotiation_organization.id, directory_organization.name,
+                                                           external_id, directory_organization.description,
+                                                           directory_organization.contact.email,
+                                                           directory_organization.url)
         else:
             LOG.info(
                 f'Organization with external id {external_id} not found, including it to the list of organizations to add')
@@ -109,11 +111,13 @@ def sync_resources(negotiator_client: NegotiatorAPIClient, directory_resources: 
                     negotiator_resource.name.strip() != directory_resource.name.strip() or
                     negotiator_resource.description.strip() != directory_resource.description.strip() or
                     directory_resource.contact is not None and negotiator_resource.contactEmail.strip() != directory_resource.contact.email.strip() or
-                    negotiator_resource.uri.strip() != directory_resource.url.strip()
+                    directory_resource.url is not None and negotiator_resource.uri.strip() != directory_resource.url.strip()
             ):
                 LOG.info(f'Updating name and/or description for resource {directory_resource.id}')
-                negotiator_client.update_resource_name_or_description(negotiator_resource.id, directory_resource.name,
-                                                                      directory_resource.description)
+                directory_resource_contact_email = directory_resource.contact.email if directory_resource.contact is not None else ''
+                negotiator_client.update_resource_data(negotiator_resource.id, directory_resource.name,
+                                                       directory_resource.description, directory_resource_contact_email,
+                                                       directory_resource.url)
     if len(resources_to_add) > 0:
         negotiator_client.add_resources(resources_to_add)
 
@@ -134,6 +138,7 @@ def sync_networks(negotiator_client: NegotiatorAPIClient, directory_networks: li
                     or network.contactEmail.strip() != directory_network.contact.email.strip()):
                 LOG.info(f'Updating name and/or url and/or contact email for network with external id: {external_id}')
                 negotiator_client.update_network_info(network.id, directory_network.name,
+                                                      directory_network.description,
                                                       directory_network.url,
                                                       directory_network.contact.email, external_id)
             LOG.info(f'Updating linked resources for network: {network.id}')

--- a/tests/integration/integration_tests.py
+++ b/tests/integration/integration_tests.py
@@ -36,7 +36,8 @@ def test_networks_initial_sync_ok():
 
 def test_organization_sync_when_new_added_and_then_updated():
     add_or_update_biobank("test_negotiator_sync", "test_negotiator_sync", "test negotiator sync",
-                          "test negotiator sync", 'insert')
+                          "test negotiator sync", 'bbmri-eric:contactID:EU_network',
+                          "http://test_negotiator_sync.org", 'insert')
 
     biobanks_after_add = get_all_biobanks()
     assert len(biobanks_after_add) == len(pytest.directory_organizations) + 1
@@ -48,7 +49,8 @@ def test_organization_sync_when_new_added_and_then_updated():
     # now update the Biobank name and sync again
 
     add_or_update_biobank("test_negotiator_sync", "test_negotiator_sync", "test negotiator sync newname",
-                          "test negotiator sync", 'update')
+                          "test negotiator sync", 'bbmri-eric:contactID:EU_network',
+                          "http://test_negotiator_sync.org", 'update')
     biobanks_after_update_name = get_all_biobanks()
     sync_organizations(pytest.negotiator_client, biobanks_after_update_name,
                        negotiator_organizations_after_bb_add_and_sync)
@@ -57,6 +59,43 @@ def test_organization_sync_when_new_added_and_then_updated():
     organization_with_name_upd = \
         [org for org in negotiator_organizations_after_update_name if org.externalId == "test_negotiator_sync"][0]
     assert organization_with_name_upd.name == "test negotiator sync newname"
+    add_or_update_biobank("test_negotiator_sync", "test_negotiator_sync", "test negotiator sync newname",
+                          "test negotiator sync newdesc", 'bbmri-eric:contactID:EU_network',
+                          "http://test_negotiator_sync.org", 'update')
+    biobanks_after_update_desc = get_all_biobanks()
+    sync_organizations(pytest.negotiator_client, biobanks_after_update_desc,
+                       negotiator_organizations_after_update_name)
+    negotiator_organizations_after_update_desc = pytest.negotiator_client.get_all_organizations()
+    assert len(negotiator_organizations_after_update_desc) == len(negotiator_organizations_after_update_name)
+    organization_with_desc_upd = \
+        [org for org in negotiator_organizations_after_update_desc if org.externalId == "test_negotiator_sync"][0]
+
+    assert organization_with_desc_upd.description == "test negotiator sync newdesc"
+    add_or_update_biobank("test_negotiator_sync", "test_negotiator_sync", "test negotiator sync newname",
+                          "test negotiator sync newdesc", 'bbmri-eric:contactID:EU_network',
+                          "http://test_negotiator_sync.org", 'update')
+    update_person_email_contact('sabrina.kralnew@medunigraz.at')
+    biobanks_after_update_email = get_all_biobanks()
+
+    sync_organizations(pytest.negotiator_client, biobanks_after_update_email,
+                       negotiator_organizations_after_update_desc)
+
+    negotiator_organizations_after_update_email = pytest.negotiator_client.get_all_organizations()
+    assert len(negotiator_organizations_after_update_email) == len(negotiator_organizations_after_update_desc)
+    organization_with_email_upd = \
+        [org for org in negotiator_organizations_after_update_email if org.externalId == "test_negotiator_sync"][0]
+    assert organization_with_email_upd.contactEmail == 'sabrina.kralnew@medunigraz.at'
+    add_or_update_biobank("test_negotiator_sync", "test_negotiator_sync", "test negotiator sync newname",
+                          "test negotiator sync newdesc", 'bbmri-eric:contactID:EU_network',
+                          "http://test_negotiator_sync_newurl.org", 'update')
+    biobanks_after_update_url = get_all_biobanks()
+    sync_organizations(pytest.negotiator_client, biobanks_after_update_url,
+                       negotiator_organizations_after_update_email)
+    negotiator_organizations_after_update_url = pytest.negotiator_client.get_all_organizations()
+    assert len(negotiator_organizations_after_update_url) == len(negotiator_organizations_after_update_email)
+    organization_with_url_upd = \
+        [org for org in negotiator_organizations_after_update_url if org.externalId == "test_negotiator_sync"][0]
+    assert organization_with_url_upd.uri == "http://test_negotiator_sync_newurl.org"
     delete_object_from_directory("test_negotiator_sync", "Biobanks")
 
 
@@ -73,7 +112,9 @@ def test_resources_sync_when_new_added_and_then_updated():
 
     ]
     add_or_update_collection("test_negotiator_sync_coll", "test negotiator sync collection",
-                             "test negotiator sync collection", network, 'insert')
+                             "test negotiator sync collection", network,
+                             'bbmri-eric:contactID:EU_network',
+                             'http://test_negotiator_sync_coll.org', 'insert')
     collections_after_add = get_all_collections()
     assert len(collections_after_add) == len(pytest.directory_resources) + 1
     negotiator_resources_before_add = pytest.negotiator_client.get_all_resources()
@@ -82,7 +123,8 @@ def test_resources_sync_when_new_added_and_then_updated():
     assert len(negotiator_resources_after_coll_add_and_sync) == len(negotiator_resources_before_add) + 1
     # now update the resource name and sync again
     add_or_update_collection("test_negotiator_sync_coll", "test negotiator sync collection newname",
-                             "test negotiator sync collection", network, 'update')
+                             "test negotiator sync collection", network, 'bbmri-eric:contactID:EU_network',
+                             'http://test_negotiator_sync_coll.org', 'update')
     collections_after_update_name = get_all_collections()
     sync_resources(pytest.negotiator_client, collections_after_update_name,
                    negotiator_resources_after_coll_add_and_sync)
@@ -93,7 +135,8 @@ def test_resources_sync_when_new_added_and_then_updated():
     assert resource_with_name_upd.name == "test negotiator sync collection newname"
     # now update the resource description and sync again
     add_or_update_collection("test_negotiator_sync_coll", "test negotiator sync collection newname",
-                             "test negotiator sync collection newdesc", network, 'update')
+                             "test negotiator sync collection newdesc", network, 'bbmri-eric:contactID:EU_network',
+                             'http://test_negotiator_sync_coll.org', 'update')
     collections_after_update_desc = get_all_collections()
     sync_resources(pytest.negotiator_client, collections_after_update_desc,
                    negotiator_resources_after_update_name)
@@ -102,6 +145,26 @@ def test_resources_sync_when_new_added_and_then_updated():
     resource_with_desc_upd = \
         [res for res in negotiator_resources_after_update_desc if res.sourceId == "test_negotiator_sync_coll"][0]
     assert resource_with_desc_upd.description == "test negotiator sync collection newdesc"
+    update_person_email_contact('sabrina.kralnew@medunigraz.at')
+    collections_after_update_email = get_all_collections()
+    sync_resources(pytest.negotiator_client, collections_after_update_email,
+                   negotiator_resources_after_update_desc)
+    negotiator_resources_after_update_email = pytest.negotiator_client.get_all_resources()
+    assert len(negotiator_resources_after_update_email) == len(negotiator_resources_after_update_desc)
+    resource_with_email_upd = \
+        [res for res in negotiator_resources_after_update_email if res.sourceId == "test_negotiator_sync_coll"][0]
+    assert resource_with_email_upd.contactEmail == 'sabrina.kralnew@medunigraz.at'
+    add_or_update_collection("test_negotiator_sync_coll", "test negotiator sync collection newname",
+                             "test negotiator sync collection newdesc", network, 'bbmri-eric:contactID:EU_network',
+                             'http://test_negotiator_sync_coll_newuri.org', 'update')
+    collections_after_update_uri = get_all_collections()
+    sync_resources(pytest.negotiator_client, collections_after_update_uri,
+                   negotiator_resources_after_update_email)
+    negotiator_resources_after_update_uri = pytest.negotiator_client.get_all_resources()
+    assert len(negotiator_resources_after_update_uri) == len(negotiator_resources_after_update_email)
+    resource_with_uri_upd = \
+        [res for res in negotiator_resources_after_update_uri if res.sourceId == "test_negotiator_sync_coll"][0]
+    assert resource_with_uri_upd.uri == 'http://test_negotiator_sync_coll_newuri.org'
     delete_object_from_directory("test_negotiator_sync_coll", 'Collections')
 
 
@@ -151,8 +214,30 @@ def test_networks_sync_when_new_added_and_then_updated():
     network_with_email_upd = \
         [ntw for ntw in negotiator_networks_after_update_email if ntw.externalId == "test_negotiator_sync_network"][0]
     assert network_with_email_upd.contactEmail == 'sabrina.kralnew@medunigraz.at'
+    add_or_update_network("test_negotiator_sync_network", "test negotiator sync network newname",
+                          "test negotiator sync network newdesc", 'http://testnew.eu',
+                          'bbmri-eric:contactID:EU_network',
+                          'update')
+
+    networks_after_update_desc = get_all_directory_networks()
+    sync_networks(pytest.negotiator_client, networks_after_update_desc, negotiator_networks_after_update_email,
+                  directory_network_resources_links)
+    negotiator_networks_after_update_desc = pytest.negotiator_client.get_all_negotiator_networks()
+    network_with_desc_upd = \
+        [ntw for ntw in negotiator_networks_after_update_desc if ntw.externalId == "test_negotiator_sync_network"][0]
+    assert network_with_desc_upd.description == "test negotiator sync network newdesc"
+    add_or_update_network("test_negotiator_sync_network", "test negotiator sync network newname",
+                          "test negotiator sync network newdesc", 'http://testnew_newuri.eu',
+                          'bbmri-eric:contactID:EU_network',
+                          'update')
+    networks_after_update_uri = get_all_directory_networks()
+    sync_networks(pytest.negotiator_client, networks_after_update_uri, negotiator_networks_after_update_desc,
+                  directory_network_resources_links)
+    negotiator_networks_after_update_uri = pytest.negotiator_client.get_all_negotiator_networks()
+    network_with_uri_upd = \
+        [ntw for ntw in negotiator_networks_after_update_uri if ntw.externalId == "test_negotiator_sync_network"][0]
+    assert network_with_uri_upd.uri == 'http://testnew_newuri.eu'
     delete_object_from_directory("test_negotiator_sync_network", 'Networks')
-    update_person_email_contact('sabrina.kral@medunigraz.at')
 
 
 def test_network_resource_links():
@@ -170,7 +255,8 @@ def test_network_resource_links():
 
     add_or_update_collection("test_negotiator_sync_coll_network_resource_links",
                              "test negotiator sync collection network resource links",
-                             "test negotiator sync collection network resource links", network, 'insert')
+                             "test negotiator sync collection network resource links", network,
+                             'bbmri-eric:contactID:EU_network', 'http://testreslinks.com', 'insert')
 
     sync_all(pytest.negotiator_client)
     negotiator_networks = pytest.negotiator_client.get_all_negotiator_networks()
@@ -195,7 +281,7 @@ def test_network_resource_links():
     add_or_update_collection("test_negotiator_sync_coll_network_resource_links",
                              "test negotiator sync collection network resource links",
                              "test negotiator sync collection network resource links", new_networks_with_added,
-                             'update')
+                             'bbmri-eric:contactID:EU_network', 'http://testreslinks.com', 'update')
     sync_all(pytest.negotiator_client)
     network_to_add_new_resources = pytest.negotiator_client.get_network_resources(network_to_add_id)
     assert len(network_to_add_new_resources) == len(network_to_add_resources) + 1
@@ -208,7 +294,7 @@ def test_network_resource_links():
     add_or_update_collection("test_negotiator_sync_coll_network_resource_links",
                              "test negotiator sync collection network resource links",
                              "test negotiator sync collection network resource links", new_networks_with_deleted,
-                             'update')
+                             'bbmri-eric:contactID:EU_network', 'http://testreslinks.com', 'update')
 
     sync_all(pytest.negotiator_client)
     network_deleted_new_resources = pytest.negotiator_client.get_network_resources(

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -7,7 +7,7 @@ from models.dto.network import NegotiatorNetworkDTO
 from .conftest import DIRECTORY_API_URL, SESSION_URL
 
 
-def add_or_update_biobank(biobank_id, biobank_pid, biobank_name, biobank_description,
+def add_or_update_biobank(biobank_id, biobank_pid, biobank_name, biobank_description, biobank_contact, biobank_url,
                           operation=Literal['insert', 'update']):
     session = pytest.directory_session
     query = f'mutation {operation}($value:[BiobanksInput]){{{operation}(Biobanks:$value){{message}}}}'
@@ -24,11 +24,12 @@ def add_or_update_biobank(biobank_id, biobank_pid, biobank_name, biobank_descrip
                     "name": "NL"
                 },
                 "contact": {
-                    "id": "bbmri-eric:contactID:NL_person1",
+                    "id": biobank_contact,
                 },
                 "juridical_person": {
                     "id": "bbmri-eric:contactID:NL_person1",
                 },
+                "url": biobank_url,
                 "national_node": {
                     "id": "NL",
                     "description": "Netherlands"
@@ -47,7 +48,8 @@ def add_or_update_biobank(biobank_id, biobank_pid, biobank_name, biobank_descrip
             f'Impossible to complete the test, erroor when adding the new biobank. Status code: {response.status_code} . Error: {response.text}')
 
 
-def add_or_update_collection(collection_id, collection_name, collection_description, network,
+def add_or_update_collection(collection_id, collection_name, collection_description, network, collection_contact,
+                             collection_url,
                              operation=Literal['insert', 'update']):
     session = pytest.directory_session
     query = f'mutation {operation}($value:[CollectionsInput]){{{operation}(Collections:$value){{message}}}}'
@@ -61,8 +63,9 @@ def add_or_update_collection(collection_id, collection_name, collection_descript
                     "name": "NL"
                 },
                 "contact": {
-                    "id": "bbmri-eric:contactID:NL_person1",
+                    "id": collection_contact
                 },
+                'url': collection_url,
                 "national_node": {
                     "id": "NL",
                     "description": "Netherlands"

--- a/utils.py
+++ b/utils.py
@@ -19,3 +19,12 @@ def get_all_directory_resources_networks_links(directory_resources: list[Resourc
                 else:
                     directory_network_resources[network.id].append(resource.id)
     return directory_network_resources
+
+
+def check_fields(negotiator_field, directory_field):
+    if directory_field is None:
+        return False
+    else:
+        if negotiator_field is None:
+            return True
+    return negotiator_field.strip() != directory_field.strip()


### PR DESCRIPTION
This PR enables synchronization for additional attributes, added to the Negotiator's entities, as: 

 - description, contact and uri for organizations; 
 - contact and uri for resources; 
 - description and uri for networks

These new attributes are get from the Directory's entities and then synced in the same way as those already present. 