### PR TITLE
Mark Negotiator's organizations and resources as withdrawn if they are not present in the Directory anymore

### DIFF
--- a/synchronization/sync_service.py
+++ b/synchronization/sync_service.py
@@ -228,8 +228,10 @@ def check_directory_missing_resources(directory_resources: list[ResourceDirector
                 LOG.info(f'Resource with external id {negotiator_resource.sourceId} is missing in the Directory'
                          f'and has not been withdrawn, marking it as withdrawn')
                 negotiator_client.update_resource_data(negotiator_resource.id, negotiator_resource.sourceId,
-                                                       negotiator_resource.name, negotiator_resource.description,
-                                                       negotiator_resource.contactEmail, True)
+                                                       negotiator_resource.name if negotiator_resource.name else '',
+                                                       negotiator_resource.description if negotiator_resource.description else '',
+                                                       negotiator_resource.contactEmail if negotiator_resource.contactEmail else '',
+                                                       True)
 
 
 @renew_access_token

--- a/tests/integration/integration_tests.py
+++ b/tests/integration/integration_tests.py
@@ -14,18 +14,43 @@ from .utils import add_or_update_biobank, delete_object_from_directory, add_or_u
 
 
 def test_organizations_initial_sync_ok():
+    initial_organization_1_id = 'bbmri-eric:ID:SE_890'
+    initial_organization_2_id = 'bbmri-eric:ID:CZ_MMCI'
+    negotiator_organizations = pytest.negotiator_client.get_all_organizations()
+    initial_organization_1 = [org for org in negotiator_organizations if org.externalId == initial_organization_1_id][0]
+    initial_organization_2 = [org for org in negotiator_organizations if org.externalId == initial_organization_2_id][0]
+    assert initial_organization_1.withdrawn == False
+    assert initial_organization_2.withdrawn == False
     sync_organizations(pytest.negotiator_client, pytest.directory_organizations,
                        pytest.initial_negotiator_organizations)
     negotiator_organizations_after_sync = pytest.negotiator_client.get_all_organizations()
     assert len(pytest.directory_organizations) == len(negotiator_organizations_after_sync) - len(
         pytest.initial_negotiator_organizations)
+    updated_initial_organization_1 = \
+        [org for org in negotiator_organizations_after_sync if org.externalId == initial_organization_1_id][0]
+    updated_initial_organization_2 = \
+        [org for org in negotiator_organizations_after_sync if org.externalId == initial_organization_2_id][0]
+    assert updated_initial_organization_1.withdrawn == True
+    assert updated_initial_organization_2.withdrawn == True
 
 
 def test_resources_initial_sync_ok():
+    initial_resource_1_id = 'bbmri-eric:ID:SE_890:collection:dummy_collection'
+    initial_resource_2_id = 'bbmri-eric:ID:CZ_MMCI:collection:LTS'
+    negotiator_resources = pytest.negotiator_client.get_all_resources()
+    initial_resource_1 = [r for r in negotiator_resources if r.sourceId == initial_resource_1_id][0]
+    initial_resource_2 = [r for r in negotiator_resources if r.sourceId == initial_resource_2_id][0]
+    assert initial_resource_1.withdrawn == False
+    assert initial_resource_2.withdrawn == False
     sync_resources(pytest.negotiator_client, pytest.directory_resources, pytest.initial_negotiator_resources)
     negotiator_resources_after_sync = pytest.negotiator_client.get_all_resources()
     assert len(pytest.directory_resources) == len(negotiator_resources_after_sync) - len(
         pytest.initial_negotiator_resources)
+    updated_initial_resource_1 = \
+        [r for r in negotiator_resources_after_sync if r.sourceId == initial_resource_1_id][0]
+    updated_initial_resource_2 = [r for r in negotiator_resources_after_sync if r.sourceId == initial_resource_2_id][0]
+    assert updated_initial_resource_1.withdrawn == True
+    assert updated_initial_resource_2.withdrawn == True
 
 
 def test_networks_initial_sync_ok():


### PR DESCRIPTION
This PR implements #14 . 
A check has been added in the service at the end of Organizations and Resources sync. Now a further check of all Negotiator's organization and resources is done in order to find Organizations and Resources that are not present in the Directory anymore. Once found, the organization/resource is automatically withdrawn if it wasn't yet in this status.  