### PR TITLE
Fix the expiration of the token when a new job cycle starts 

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,23 +2,24 @@ from datetime import datetime
 
 import schedule
 
-from auth import get_token
+from auth import get_token, renew_access_token
 from clients.negotiator_client import NegotiatorAPIClient
 from config import LOG, NEGOTIATOR_API_URL, JOB_SCHEDULE_INTERVAL
 from synchronization.sync_service import sync_all
 
 
-def cron_job(negotiator_client):
+def cron_job():
     LOG.info(f"Starting cron job at: {datetime.now()}")
+    negotiator_client = NegotiatorAPIClient(NEGOTIATOR_API_URL, get_token())
     sync_all(negotiator_client)
 
 
 def sync_directory():
-    negotiator_client = NegotiatorAPIClient(NEGOTIATOR_API_URL, get_token())
-    schedule.every(int(JOB_SCHEDULE_INTERVAL)).seconds.do(cron_job, negotiator_client)
+    schedule.every(int(JOB_SCHEDULE_INTERVAL)).seconds.do(cron_job)
 
 
 def run_microservice():
+    cron_job()
     sync_directory()
     while True:
         schedule.run_pending()


### PR DESCRIPTION
This PR fixes #16. In the main module, that starts the job cron, it moves the Negotiator's client instantiation (and so the token creation) after the job cycle beginning, and not before as it was (and also was the cause of this issue). 
Now, at every cycle, the negotiation client and the token are created, and no token expire issue due to an old token usage is raised anymore. 
Also, this PR adds a job cycle immediately at the beginning of the microservice start, in a way that we have not to wait for an interval to execute it for the first time. 