### PR TITLE
Add sync of National Nodes

### DIFF
--- a/clients/directory_client.py
+++ b/clients/directory_client.py
@@ -26,6 +26,10 @@ def get_emx2_biobank_query():
                           id 
                           name 
                           description
+                          national_node {
+                            id
+                            description
+                            }
                         }
                     }
   
@@ -139,7 +143,11 @@ def get_all_directory_services(biobanks: list[OrganizationDirectoryDTO]):
                 description
                 contactInformation {
                     email
-                }             
+                } 
+                national_node {
+                    id       
+                    description
+                }
             }  
     }       
     '''
@@ -155,7 +163,8 @@ def get_all_directory_services(biobanks: list[OrganizationDirectoryDTO]):
                                                               description=service['description'],
                                                               biobank=service_biobank,
                                                               contactEmail=service['contactInformation'][
-                                                                  'email'] if 'contactInformation' in service else '')
+                                                                  'email'] if 'contactInformation' in service else '',
+                                                              national_node=service['national_node'])
             parsed_services.append(service_resource_directory)
         return parsed_services
     return []

--- a/clients/directory_client.py
+++ b/clients/directory_client.py
@@ -162,3 +162,34 @@ def get_biobank_by_service(biobanks: list[OrganizationDirectoryDTO], service_id)
         for service in b.services:
             if service.id == service.id:
                 return b
+
+
+def get_all_directory_national_nodes():
+    em2x_national_nodes_query = '''
+    {
+        NationalNodes{
+            id
+            description
+            dns
+            contact_persons{
+                id
+                email
+            }
+        }
+    }
+    '''
+    response = requests.post(DIRECTORY_API_URL, json={'query': em2x_national_nodes_query})
+    if response.status_code not in SUCCESS_CODES:
+        raise DirectoryAPIException(
+            f'Error occurred while trying to get National Nodes from the Directory API: {response.text}')
+    results = response.json()
+    parsed_networks_from_national_nodes = list()
+    nn_network_label = 'National Node Network'
+    for national_node in results['data']['NationalNodes']:
+        national_node_network_directory = NetworkDirectoryDTO(
+            id=national_node['id'],
+            name=f'{national_node['description']} {nn_network_label}',
+            description=f'{national_node['description']} {nn_network_label}',
+        )
+        parsed_networks_from_national_nodes.append(national_node_network_directory)
+    return parsed_networks_from_national_nodes

--- a/clients/directory_client.py
+++ b/clients/directory_client.py
@@ -89,7 +89,11 @@ def get_all_collections():
                         email
                         }
                 }
-                }  
+                national_node {
+                    id
+                    description
+                }
+            }  
     }
     
     '''

--- a/clients/negotiator_client.py
+++ b/clients/negotiator_client.py
@@ -185,8 +185,8 @@ def network_create_dto(network: NetworkDirectoryDTO):
         'externalId': network.id,
         'name': network.name,
         'description': network.description,
-        'contactEmail': network.contact.email,
-        'uri': create_network_production_uri(network.id)
+        'contactEmail': network.contact.email if network.contact else '',
+        'uri': create_network_production_uri(network.id) if len(network.id) > 3 else '',
     }
 
 

--- a/clients/negotiator_client.py
+++ b/clients/negotiator_client.py
@@ -185,7 +185,7 @@ def network_create_dto(network: NetworkDirectoryDTO):
         'externalId': network.id,
         'name': network.name,
         'description': network.description,
-        'contactEmail': network.contact.email if network.contact else '',
+        'contactEmail': network.contact.email if (network.contact and not isinstance(network.contact, str)) else '',
         'uri': create_network_production_uri(network.id) if len(network.id) > 3 else '',
     }
 

--- a/models/dto/national_node.py
+++ b/models/dto/national_node.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+
+class NationalNode(BaseModel):
+    id: str
+    description: str

--- a/models/dto/network.py
+++ b/models/dto/network.py
@@ -12,7 +12,7 @@ class NetworkDirectoryDTO(BaseModel):
     name: str
     description: str
     url: Optional[str] = ''
-    contact: Contact
+    contact: Optional[Contact] = ''
 
     @staticmethod
     def parse(directory_data):

--- a/models/dto/organization.py
+++ b/models/dto/organization.py
@@ -2,15 +2,11 @@ from typing import Optional
 
 from pydantic import BaseModel, Field, ConfigDict
 
+from models.dto.service import ServiceDirectoryDTO
+
 
 class Contact(BaseModel):
     email: str
-
-
-class ServiceDirectoryDTO(BaseModel):
-    id: str
-    name: str
-    description: Optional[str]
 
 
 class OrganizationDirectoryDTO(BaseModel):

--- a/models/dto/resource.py
+++ b/models/dto/resource.py
@@ -2,17 +2,13 @@ from typing import Optional
 
 from pydantic import BaseModel, Field
 
+from .national_node import NationalNode
 from .network import NetworkDirectoryDTO
 from ..dto.organization import OrganizationDirectoryDTO
 
 
 class Contact(BaseModel):
     email: str
-
-
-class NationalNode(BaseModel):
-    id: str
-    description: str
 
 
 class ResourceDirectoryDTO(BaseModel):

--- a/models/dto/resource.py
+++ b/models/dto/resource.py
@@ -10,6 +10,11 @@ class Contact(BaseModel):
     email: str
 
 
+class NationalNode(BaseModel):
+    id: str
+    description: str
+
+
 class ResourceDirectoryDTO(BaseModel):
     id: str
     name: str
@@ -19,6 +24,7 @@ class ResourceDirectoryDTO(BaseModel):
     biobank: OrganizationDirectoryDTO
     network: Optional[list[NetworkDirectoryDTO]] = None
     withdrawn: bool = Field(default=False)
+    national_node: Optional[NationalNode]
 
     @staticmethod
     def parse(directory_data):

--- a/models/dto/service.py
+++ b/models/dto/service.py
@@ -1,0 +1,12 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+from models.dto.national_node import NationalNode
+
+
+class ServiceDirectoryDTO(BaseModel):
+    id: str
+    name: str
+    description: Optional[str]
+    national_node: Optional[NationalNode]

--- a/synchronization/sync_service.py
+++ b/synchronization/sync_service.py
@@ -2,7 +2,7 @@ import requests
 
 from auth import renew_access_token
 from clients.directory_client import (get_all_biobanks, get_all_collections, get_all_directory_networks,
-                                      get_all_directory_services)
+                                      get_all_directory_services, get_all_directory_national_nodes)
 from clients.negotiator_client import resource_create_dto, network_create_dto, NegotiatorAPIClient, \
     get_resource_id_by_source_id, organization_create_dto
 from config import LOG
@@ -57,7 +57,7 @@ def sync_all(negotiator_client: NegotiatorAPIClient):
         directory_network_resources_links = get_all_directory_resources_networks_links(directory_resources)
         negotiator_resources = negotiator_client.get_all_resources()
         sync_resources(negotiator_client, directory_resources, negotiator_resources)
-        directory_networks = get_all_directory_networks()
+        directory_networks = get_all_directory_networks() + get_all_directory_national_nodes()
         negotiator_networks = negotiator_client.get_all_negotiator_networks()
         sync_networks(negotiator_client, directory_networks, negotiator_networks,
                       directory_network_resources_links)

--- a/synchronization/sync_service.py
+++ b/synchronization/sync_service.py
@@ -64,7 +64,7 @@ def sync_all(negotiator_client: NegotiatorAPIClient):
 
     except requests.exceptions.ConnectionError as e:
         LOG.error(
-            f'Error occurred while trying to connect to one f the dependent services required for sync (Negotiator, Lifescience AAI, Directory): {e}')
+            f'Error occurred while trying to connect to one of the dependent services required for sync (Negotiator, Lifescience AAI, Directory): {e}')
         if job_id:
             negotiator_client.update_sync_job(job_id, 'FAILED')
 
@@ -166,14 +166,16 @@ def sync_networks(negotiator_client: NegotiatorAPIClient, directory_networks: li
         external_id = directory_network.id
         network = get_negotiator_network_by_external_id(negotiator_networks, external_id)
         if network:
+            directory_network_contact_email = getattr(directory_network.contact, 'email', None) if hasattr(
+                directory_network.contact, 'email') else None
             if (check_fields(network.name, directory_network.name) or
                     check_fields(network.description, directory_network.description)
-                    or check_fields(network.contactEmail, directory_network.contact.email) or
+                    or check_fields(network.contactEmail, directory_network_contact_email) or
                     check_uri(network.uri)):
                 LOG.info(f'Updating name and/or url and/or contact email for network with external id: {external_id}')
                 negotiator_client.update_network_info(network.id, directory_network.name,
                                                       directory_network.description,
-                                                      directory_network.contact.email, external_id)
+                                                      directory_network_contact_email, external_id)
             LOG.info(f'Updating linked resources for network: {network.id}')
             update_network_resources(negotiator_client, network.id, network.externalId,
                                      directory_network_resources_links)

--- a/tests/integration/integration_tests.py
+++ b/tests/integration/integration_tests.py
@@ -490,3 +490,10 @@ def test_national_nodes_sync():
     sync_all(pytest.negotiator_client)
     networks_after_sync = pytest.negotiator_client.get_all_negotiator_networks()
     assert len(networks_after_sync) == len(networks_before_sync) + 1
+    add_or_update_national_node("TT", "TestUpdated", "update")
+    sync_all(pytest.negotiator_client)
+    networks_after_update = pytest.negotiator_client.get_all_negotiator_networks()
+    updated_network_from_nn = [n for n in networks_after_update if n.externalId == "TT"][0]
+    assert updated_network_from_nn.name == "TestUpdated National Node Network"
+    assert updated_network_from_nn.description == "TestUpdated National Node Network"
+

--- a/tests/integration/integration_tests.py
+++ b/tests/integration/integration_tests.py
@@ -10,7 +10,8 @@ from synchronization.sync_service import sync_organizations, sync_resources, syn
     sync_all
 from utils import get_all_directory_resources_networks_links
 from .utils import add_or_update_biobank, delete_object_from_directory, add_or_update_collection, \
-    add_or_update_network, update_person_email_contact, get_negotiator_network_id_by_external_id, add_or_update_service
+    add_or_update_network, update_person_email_contact, get_negotiator_network_id_by_external_id, add_or_update_service, \
+    add_or_update_national_node
 
 
 def test_organizations_initial_sync_ok():
@@ -481,3 +482,11 @@ def test_service_sync():
     resources_after_sync = pytest.negotiator_client.get_all_resources()
     service_after_sync = get_resource_by_source_id('bbmri-eric:serviceID:DE_1234', resources_after_sync)
     assert service_after_sync.name == 'Biobank service_newname'
+
+
+def test_national_nodes_sync():
+    networks_before_sync = pytest.negotiator_client.get_all_negotiator_networks()
+    add_or_update_national_node("TT", "Test", "insert")
+    sync_all(pytest.negotiator_client)
+    networks_after_sync = pytest.negotiator_client.get_all_negotiator_networks()
+    assert len(networks_after_sync) == len(networks_before_sync) + 1

--- a/tests/integration/integration_tests.py
+++ b/tests/integration/integration_tests.py
@@ -496,4 +496,15 @@ def test_national_nodes_sync():
     updated_network_from_nn = [n for n in networks_after_update if n.externalId == "TT"][0]
     assert updated_network_from_nn.name == "TestUpdated National Node Network"
     assert updated_network_from_nn.description == "TestUpdated National Node Network"
+    add_or_update_collection("test_negotiator_sync_coll", "test negotiator sync collection",
+                             "test negotiator sync collection", [],
+                             'bbmri-eric:contactID:EU_network',
+                             False, 'insert', nn_id='TT', nn_description='TestUpdated National Node Network')
 
+    sync_all(pytest.negotiator_client)
+    negotiator_networks = pytest.negotiator_client.get_all_negotiator_networks()
+    tt_network_id = get_negotiator_network_id_by_external_id(
+        "TT", negotiator_networks)
+    tt_resources_links = pytest.negotiator_client.get_network_resources(
+        tt_network_id)
+    assert len(tt_resources_links) == 1

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -49,7 +49,7 @@ def add_or_update_biobank(biobank_id, biobank_pid, biobank_name, biobank_descrip
 
 def add_or_update_collection(collection_id, collection_name, collection_description, network, collection_contact,
                              collection_withdrawn,
-                             operation=Literal['insert', 'update']):
+                             operation=Literal['insert', 'update'], nn_id='NL', nn_description='Netherlands'):
     session = pytest.directory_session
     query = f'mutation {operation}($value:[CollectionsInput]){{{operation}(Collections:$value){{message}}}}'
     variables = {
@@ -66,8 +66,8 @@ def add_or_update_collection(collection_id, collection_name, collection_descript
                 },
                 'withdrawn': collection_withdrawn,
                 "national_node": {
-                    "id": "NL",
-                    "description": "Netherlands"
+                    "id": nn_id,
+                    "description": nn_description
                 },
                 "network": network,
                 "biobank": {
@@ -224,13 +224,13 @@ def add_or_update_service(service_id, service_name, service_description, operati
             f'Impossible to complete the test, erroor when adding the new Service. Status code: {response.status_code} . Error: {response.text}')
 
 
-def add_or_update_national_node(nn_id, nn_description,operation=Literal['insert', 'update']):
+def add_or_update_national_node(nn_id, nn_description, operation=Literal['insert', 'update']):
     session = pytest.directory_session
     query = f'mutation {operation}($value:[NationalNodesInput]){{{operation}(NationalNodes:$value){{message}}}}'
-    national_node = {"id":nn_id,
+    national_node = {"id": nn_id,
                      "description": nn_description,
-                     "data_refresh":{"name":"manual"},
-                     "mg_draft":False
+                     "data_refresh": {"name": "manual"},
+                     "mg_draft": False
                      }
     variables = {
         "value": [national_node]

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -222,3 +222,21 @@ def add_or_update_service(service_id, service_name, service_description, operati
     if response.status_code != 200:
         raise Exception(
             f'Impossible to complete the test, erroor when adding the new Service. Status code: {response.status_code} . Error: {response.text}')
+
+
+def add_or_update_national_node(nn_id, nn_description,operation=Literal['insert', 'update']):
+    session = pytest.directory_session
+    query = f'mutation {operation}($value:[NationalNodesInput]){{{operation}(NationalNodes:$value){{message}}}}'
+    national_node = {"id":nn_id,
+                     "description": nn_description,
+                     "data_refresh":{"name":"manual"},
+                     "mg_draft":False
+                     }
+    variables = {
+        "value": [national_node]
+    }
+    response = session.post(DIRECTORY_API_URL, json={'query': query, 'variables': variables},
+                            auth=HTTPBasicAuth('admin', 'admin'))
+    if response.status_code != 200:
+        raise Exception(
+            f'Impossible to complete the test, error when adding the new National Node. Status code: {response.status_code} . Error: {response.text}')

--- a/utils.py
+++ b/utils.py
@@ -20,6 +20,11 @@ def get_all_directory_resources_networks_links(directory_resources: list[Resourc
                     directory_network_resources[network.id] = [resource.id]
                 else:
                     directory_network_resources[network.id].append(resource.id)
+        if resource.national_node is not None:
+            if resource.national_node.id not in directory_network_resources.keys():
+                directory_network_resources[resource.national_node.id] = [resource.id]
+            else:
+                directory_network_resources[resource.national_node.id].append(resource.id)
     return directory_network_resources
 
 
@@ -34,17 +39,21 @@ def check_fields(negotiator_field, directory_field):
     else:
         return negotiator_field != directory_field
 
+
 def check_uri(uri_field):
-    if uri_field is None or uri_field =='' or not uri_field.startswith(DIRECTORY_BASE_URI):
+    if uri_field is None or uri_field == '' or not uri_field.startswith(DIRECTORY_BASE_URI):
         return True
     else:
         return False
 
+
 def create_biobank_production_uri(biobank_id):
     return f'{DIRECTORY_BASE_URI}biobank/{biobank_id}'
 
+
 def create_collection_production_uri(collection_id):
     return f'{DIRECTORY_BASE_URI}collection/{collection_id}'
+
 
 def create_network_production_uri(network_id):
     return f'{DIRECTORY_BASE_URI}network/{network_id}'


### PR DESCRIPTION
This PR adds the sync of National Nodes (NNs) from the Directory. The NNs are added as networks, and their ID in the Directory(the 2-digits state code of a NN) is taken as externalID in the added Negotiator's Network. The name ad description instead, have this pattern: "[Directory NN description] National Node Network".
The PR implements https://github.com/BBMRI-ERIC/directory-negotiator-sync/issues/18 .