### PR TITLE
Add health endpoint 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.12-alpine3.20
 
+RUN apk add --no-cache curl
+
 RUN mkdir -p /opt/directory-negotiator-sync
 
 COPY ./clients /opt/directory-negotiator-sync/clients
@@ -23,7 +25,7 @@ ENV PYTHONPATH=/opt/directory-negotiator-sync
 
 EXPOSE 8088
 
-HEALTHCHECK --interval=30s --timeout=10s CMD curl -f http://localhost:8081/api/actuator/health || exit 1
+HEALTHCHECK --interval=30s --timeout=10s CMD curl -f http://localhost:8088/api/actuator/health || exit 1
 
 CMD ["python",  "main.py"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY ./auth.py /opt/directory-negotiator-sync/auth.py
 COPY ./config.py /opt/directory-negotiator-sync/config.py
 COPY ./exceptions.py /opt/directory-negotiator-sync/exceptions.py
 COPY ./utils.py /opt/directory-negotiator-sync/utils.py
+COPY ./health.py /opt/directory-negotiator-sync/health.py
 COPY ./main.py /opt/directory-negotiator-sync/main.py
 COPY ./requirements.txt /opt/directory-negotiator-sync/requirements.txt
 
@@ -19,6 +20,10 @@ WORKDIR /opt/directory-negotiator-sync
 RUN pip install -r requirements.txt
 
 ENV PYTHONPATH=/opt/directory-negotiator-sync
+
+EXPOSE 8088
+
+HEALTHCHECK --interval=30s --timeout=10s CMD curl -f http://localhost:8081/api/actuator/health || exit 1
 
 CMD ["python",  "main.py"]
 

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ You can also run the integration test in case of multiple Directories:
 
 ## Health endpoint 
 
-An endpoint to check that the microservice is up and running is available on port 8080. The endpoint to call is:
+An endpoint to check that the microservice is up and running is available on port 8088. The endpoint to call is:
 
-` http://[YOUR_HOST]:8080/api/actuator/health `
+` http://[YOUR_HOST]:8088/api/actuator/health `
 
 In case of healthiness, a GET to the previous endpoint will return 200 with this response: 
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ You can also run the integration test in case of multiple Directories:
 ` pytest integration_tests_multiple_directories.py `
 
 
+## Health endpoint 
 
+An endpoint to check that the microservice is up and running is available on port 8080. The endpoint to call is:
+
+` http://[YOUR_HOST]:8080/api/actuator/health `
+
+In case of healthiness, a GET to the previous endpoint will return 200 with this response: 
+
+` {"status":"UP"} `
 
 

--- a/compose/docker-compose-deploy.yml
+++ b/compose/docker-compose-deploy.yml
@@ -6,6 +6,8 @@ services:
       context: ..
     volumes:
       - ./local_config.yaml:/opt/directory-negotiator-sync/config.yaml:ro
+    ports:
+      - "8088:8088"
     networks:
       - directory-negotiator-sync-network
 networks:

--- a/health.py
+++ b/health.py
@@ -1,0 +1,15 @@
+import threading
+import uvicorn
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/api/actuator/health")
+def health():
+    return {"status": "UP"}
+
+def start(port=8088):
+    threading.Thread(
+        target=lambda: uvicorn.run(app, host="0.0.0.0", port=port, log_level="error"),
+        daemon=True
+    ).start()

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 import schedule
 
+import health
 from auth import get_token
 from clients.negotiator_client import NegotiatorAPIClient
 from config import LOG, NEGOTIATOR_API_URL, JOB_SCHEDULE_INTERVAL, DIRECTORY_SOURCES
@@ -62,6 +63,7 @@ def run_microservice():
     """
     Main method to run the microservice.
     """
+    health.start()
     cron_job()
     sync_directory()
     while True:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,5 @@ schedule==1.2.2
 typing_extensions==4.12.2
 urllib3==2.2.3
 docker~=7.1.0
+fastapi==0.135.3
+uvicorn==0.44.0

--- a/tests/deployment/standalone_service_test.py
+++ b/tests/deployment/standalone_service_test.py
@@ -96,8 +96,9 @@ def test_service_logs(setup_docker_compose):
         in logs
     )
 
-def test_service_health():
+def test_service_health(setup_docker_compose):
     health_url = 'http://localhost:8088/api/actuator/health'
+    wait_for_service(health_url)
     response  = requests.get(health_url)
     assert response.status_code == 200
     assert response.json()["status"] == "UP"

--- a/tests/deployment/standalone_service_test.py
+++ b/tests/deployment/standalone_service_test.py
@@ -99,7 +99,7 @@ def test_service_logs(setup_docker_compose):
 def test_service_health(setup_docker_compose):
     health_url = 'http://localhost:8088/api/actuator/health'
     wait_for_service(health_url)
-    response  = requests.get(health_url)
+    response = requests.get(health_url)
     assert response.status_code == 200
     assert response.json()["status"] == "UP"
 

--- a/tests/deployment/standalone_service_test.py
+++ b/tests/deployment/standalone_service_test.py
@@ -12,7 +12,6 @@ client = docker.from_env()
 # Paths to Docker Compose files
 COMPOSE_FILE_SERVICES = "../../compose/docker-compose-run-services-for-deploy.yml"
 COMPOSE_FILE_APP = "../../compose/docker-compose-deploy.yml"
-WAIT_FOR_SERVICE_START = time.time()
 WAIT_FOR_SERVICE_TIMEOUT = 300
 
 
@@ -28,7 +27,8 @@ def stop_compose(compose_file):
 
 def wait_for_service(url):
     """Waits for the given services to be healthy."""
-    while time.time() - WAIT_FOR_SERVICE_START < WAIT_FOR_SERVICE_TIMEOUT:
+    wait_start = time.time()
+    while time.time() - wait_start < WAIT_FOR_SERVICE_TIMEOUT:
         try:
             response = requests.get(url)
             if response.status_code == 200:

--- a/tests/deployment/standalone_service_test.py
+++ b/tests/deployment/standalone_service_test.py
@@ -95,3 +95,10 @@ def test_service_logs(setup_docker_compose):
         "Network with id bbmri-eric:networkID:EU_network coming from source http://emx2:8080/ERIC/directory/graphql not found, adding it to the list of networks to add"
         in logs
     )
+
+def test_service_health():
+    health_url = 'http://localhost:8088/api/actuator/health'
+    response  = requests.get(health_url)
+    assert response.status_code == 200
+    assert response.json()["status"] == "UP"
+


### PR DESCRIPTION
This PR Implements #25 and adds an endpoint /api/actuator/health on port 8088 to check that the microservice is up and running 