### PR TITLE
Fix #28 and configure  integration tests and CI  to be run over different Directory versions 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,55 +20,96 @@ jobs:
         uses: actions/checkout@v4.2.2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.7.1
-      - name: Run compose
+      - name: Run compose (v11.34.0)
+        env:
+          DIRECTORY_VERSION: v11.34.0
         run: |  
-         cd $GITHUB_WORKSPACE/compose
-         docker compose -f docker-compose-integration-tests.yml  up -d
+          cd $GITHUB_WORKSPACE/compose
+          docker compose -f docker-compose-integration-tests.yml up -d
       - name: Prepare python environment
         run: |
-         cd $GITHUB_WORKSPACE
-         pip install -r requirements.txt
+          cd $GITHUB_WORKSPACE
+          pip install -r requirements.txt
       - name: Wait for Directory service
         run: |
           cd $GITHUB_WORKSPACE/tests/scripts
           python wait_for_service.py
       - name: Load test data for Directory
         run: |
-         cd $GITHUB_WORKSPACE
-         python -m tests.scripts.load_directory_data
-         sleep 120
-      - name: Run Integration tests with one source directory
-        run: | 
-         cd $GITHUB_WORKSPACE/tests/integration
-         pytest integration_tests_single_directory.py
-      - name: Run Integration tests with multiple directory sources
+          cd $GITHUB_WORKSPACE
+          python -m tests.scripts.load_directory_data
+          sleep 60
+      - name: Run Integration tests with one source directory (v11.34.0)
+        env:
+          DIRECTORY_VERSION: v11.34.0
+        run: |
+          cd $GITHUB_WORKSPACE/tests/integration
+          pytest integration_tests_single_directory.py
+      - name: Run Integration tests with multiple directory sources (v11.34.0)
+        env:
+          DIRECTORY_VERSION: v11.34.0
         run: |
           cd $GITHUB_WORKSPACE/tests/integration
           pytest integration_tests_multiple_directories.py
-      - name: Down compose
+      - name: Down compose (v11.34.0)
         run: |
           cd $GITHUB_WORKSPACE/compose
-          docker compose -f docker-compose-integration-tests.yml  down
+          docker compose -f docker-compose-integration-tests.yml down
+
+      - name: Run compose (latest)
+        env:
+          DIRECTORY_VERSION: latest
+        run: |  
+          cd $GITHUB_WORKSPACE/compose
+          docker compose -f docker-compose-integration-tests.yml up -d
+      - name: Prepare python environment
+        run: |
+          cd $GITHUB_WORKSPACE
+          pip install -r requirements.txt
+      - name: Wait for Directory service
+        run: |
+          cd $GITHUB_WORKSPACE/tests/scripts
+          python wait_for_service.py
+      - name: Load test data for Directory
+        run: |
+          cd $GITHUB_WORKSPACE
+          python -m tests.scripts.load_directory_data
+          sleep 60
+      - name: Run Integration tests with one source directory (latest)
+        env:
+          DIRECTORY_VERSION: latest
+        run: |
+          cd $GITHUB_WORKSPACE/tests/integration
+          pytest integration_tests_single_directory.py
+      - name: Run Integration tests with multiple directory sources (latest)
+        env:
+          DIRECTORY_VERSION: latest
+        run: |
+          cd $GITHUB_WORKSPACE/tests/integration
+          pytest integration_tests_multiple_directories.py
+      - name: Down compose (latest)
+        run: |
+          cd $GITHUB_WORKSPACE/compose
+          docker compose -f docker-compose-integration-tests.yml down
+
       - name: Run service deploy tests
         run: |
           cd $GITHUB_WORKSPACE/tests/deployment
           pytest standalone_service_test.py
+
   build-docker-image:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.2.2
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.7.1
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5
@@ -81,7 +122,6 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
-
       - name: Build and push
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6
         with:
@@ -90,6 +130,4 @@ jobs:
           push: true
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
-          build-args: ARTIFACT_VERSION=${{  github.ref_name }}
-
-    
+          build-args: ARTIFACT_VERSION=${{ github.ref_name }}

--- a/clients/directory_client.py
+++ b/clients/directory_client.py
@@ -261,9 +261,10 @@ class DirectoryClient:
             The service matching object, or none if the sSrvice is not linked to any Biobank
         """
         for b in biobanks:
-            for service in b.services:
-                if service.id == service_id:
-                    return b
+            if b.services:
+                for service in b.services:
+                    if service.id == service_id:
+                        return b
         return None
 
     def get_all_directory_national_nodes(self):

--- a/compose/docker-compose-integration-tests.yml
+++ b/compose/docker-compose-integration-tests.yml
@@ -79,7 +79,7 @@ services:
     networks:
       - directory-negotiator-sync-test
   emx2:
-    image: molgenis/molgenis-emx2:v11.34.0
+    image: molgenis/molgenis-emx2:${DIRECTORY_VERSION}
     environment:
       - TZ=Europe/Rome
       - MOLGENIS_POSTGRES_URI=jdbc:postgresql://postgres:5432/molgenis
@@ -113,7 +113,7 @@ services:
     networks:
       - directory-negotiator-sync-test
   emx2-second-source:
-    image: molgenis/molgenis-emx2:v11.34.0
+    image: molgenis/molgenis-emx2:${DIRECTORY_VERSION}
     environment:
       - TZ=Europe/Rome
       - MOLGENIS_POSTGRES_URI=jdbc:postgresql://postgres-second-source:5432/molgenis
@@ -147,7 +147,7 @@ services:
     networks:
       - directory-negotiator-sync-test
   emx2-third-source:
-    image: molgenis/molgenis-emx2:v11.34.0
+    image: molgenis/molgenis-emx2:${DIRECTORY_VERSION}
     environment:
       - TZ=Europe/Rome
       - MOLGENIS_POSTGRES_URI=jdbc:postgresql://postgres-third-source:5432/molgenis

--- a/compose/docker-compose-integration-tests.yml
+++ b/compose/docker-compose-integration-tests.yml
@@ -79,7 +79,7 @@ services:
     networks:
       - directory-negotiator-sync-test
   emx2:
-    image: molgenis/molgenis-emx2:${DIRECTORY_VERSION}
+    image: molgenis/molgenis-emx2:${DIRECTORY_VERSION:-latest}
     environment:
       - TZ=Europe/Rome
       - MOLGENIS_POSTGRES_URI=jdbc:postgresql://postgres:5432/molgenis
@@ -113,7 +113,7 @@ services:
     networks:
       - directory-negotiator-sync-test
   emx2-second-source:
-    image: molgenis/molgenis-emx2:${DIRECTORY_VERSION}
+    image: molgenis/molgenis-emx2:${DIRECTORY_VERSION:-latest}
     environment:
       - TZ=Europe/Rome
       - MOLGENIS_POSTGRES_URI=jdbc:postgresql://postgres-second-source:5432/molgenis
@@ -147,7 +147,7 @@ services:
     networks:
       - directory-negotiator-sync-test
   emx2-third-source:
-    image: molgenis/molgenis-emx2:${DIRECTORY_VERSION}
+    image: molgenis/molgenis-emx2:${DIRECTORY_VERSION:-latest}
     environment:
       - TZ=Europe/Rome
       - MOLGENIS_POSTGRES_URI=jdbc:postgresql://postgres-third-source:5432/molgenis

--- a/tests/integration/integration_tests_multiple_directories.py
+++ b/tests/integration/integration_tests_multiple_directories.py
@@ -6,6 +6,7 @@ import config
 import utils
 
 #override configuration for the test
+DIRECTORY_VERSION = os.environ.get('DIRECTORY_VERSION')
 base_dir = os.path.dirname(os.path.abspath(__file__))
 test_yaml = os.path.join(base_dir, "../config/config_tests.yaml")
 config.load_config(test_yaml)
@@ -119,7 +120,7 @@ def test_sync_common_biobank_sources_2_3_updated_by_source_2():
         "bbmri-eric:contactID:EU_network",
         "false",
         "bbmri-eric:serviceID:DE_1234",
-        "update",
+        "insert",
     )
 
     cron_job()
@@ -393,6 +394,8 @@ def test_sync_common_services_all_sources_updated_by_source_1():
         common_service_all_sources_id,
         "Biobank service name source 1",
         "Service provided by this biobank source 1",
+        "bbmri-eric:ID:NL_biobank2",
+        DIRECTORY_VERSION,
         "update"
     )
 
@@ -402,6 +405,8 @@ def test_sync_common_services_all_sources_updated_by_source_1():
         common_service_all_sources_id,
         "Biobank service name source 2",
         "Service provided by this biobank source 2",
+        "bbmri-eric:ID:NL_biobank2",
+        DIRECTORY_VERSION,
         "update"
     )
 
@@ -411,6 +416,8 @@ def test_sync_common_services_all_sources_updated_by_source_1():
         common_service_all_sources_id,
         "Biobank service name source 3",
         "Service provided by this biobank source 3",
+        "bbmri-eric:ID:NL_biobank2",
+        DIRECTORY_VERSION,
         "update"
     )
 
@@ -430,6 +437,8 @@ def test_sync_common_services_sources_2_3_updated_by_source_2():
         "common_service_sources_2_3",
         "Common service sources 2 and 3 name source 2",
         "Common service sources 2 and 3 description source 2",
+        "bbmri-eric:ID:NL_biobank_upd_source_2",
+        DIRECTORY_VERSION,
         "insert"
     )
 
@@ -439,6 +448,8 @@ def test_sync_common_services_sources_2_3_updated_by_source_2():
         "common_service_sources_2_3",
         "Common service sources 2 and 3 name source 3",
         "Common service sources 2 and 3 description source 3",
+        "bbmri-eric:ID:NL_biobank_upd_source_2",
+        DIRECTORY_VERSION,
         "insert"
     )
     add_or_update_biobank(
@@ -486,6 +497,8 @@ def test_sync_service_when_present_in_source_3_only():
         "unique_service_source_3",
         "Unique service source 3 name",
         "Unique service source 3 description",
+        "bbmri-eric:ID:NL_biobank_source_3_exclusive",
+        DIRECTORY_VERSION,
         "insert"
     )
     add_or_update_biobank(

--- a/tests/integration/integration_tests_multiple_directories.py
+++ b/tests/integration/integration_tests_multiple_directories.py
@@ -6,7 +6,7 @@ import config
 import utils
 
 #override configuration for the test
-DIRECTORY_VERSION = os.environ.get('DIRECTORY_VERSION')
+DIRECTORY_VERSION = os.environ.get('DIRECTORY_VERSION', 'latest')
 base_dir = os.path.dirname(os.path.abspath(__file__))
 test_yaml = os.path.join(base_dir, "../config/config_tests.yaml")
 config.load_config(test_yaml)

--- a/tests/integration/integration_tests_single_directory.py
+++ b/tests/integration/integration_tests_single_directory.py
@@ -7,7 +7,7 @@ import pytest
 
 import utils
 
-DIRECTORY_VERSION = os.environ.get('DIRECTORY_VERSION')
+DIRECTORY_VERSION = os.environ.get('DIRECTORY_VERSION', 'latest')
 
 # override configuration for the test
 base_dir = os.path.dirname(os.path.abspath(__file__))
@@ -850,7 +850,7 @@ def test_biobank_sync_when_no_service_added():
         "Biobank with no services",
         "bbmri-eric:contactID:EU_network",
         "false",
-        None,
+        [],
         "insert",
     )
     negotiator_organizations_before_adding_biobank = pytest.negotiator_client.get_all_organizations()

--- a/tests/integration/integration_tests_single_directory.py
+++ b/tests/integration/integration_tests_single_directory.py
@@ -7,6 +7,8 @@ import pytest
 
 import utils
 
+DIRECTORY_VERSION = os.environ.get('DIRECTORY_VERSION')
+
 # override configuration for the test
 base_dir = os.path.dirname(os.path.abspath(__file__))
 test_yaml = os.path.join(base_dir, "../config/config_tests_single_directory.yaml")
@@ -789,6 +791,8 @@ def test_service_sync():
         "bbmri-eric:serviceID:DE_1234",
         "Biobank service_newname",
         "Service provided by this biobank",
+        'bbmri-eric:ID:DE_biobank1',
+        DIRECTORY_VERSION,
         "update",
     )
 
@@ -834,3 +838,25 @@ def test_national_nodes_sync():
     tt_network_id = get_negotiator_network_id_by_external_id("TT", negotiator_networks)
     tt_resources_links = pytest.negotiator_client.get_network_resources(tt_network_id)
     assert len(tt_resources_links) == 1
+
+
+def test_biobank_sync_when_no_service_added():
+    biobank_with_no_services = add_or_update_biobank(
+        session,
+        directory_url,
+        "test_bb_no_services",
+        "test_bb_no_services",
+        "Biobank with no services",
+        "Biobank with no services",
+        "bbmri-eric:contactID:EU_network",
+        "false",
+        None,
+        "insert",
+    )
+    negotiator_organizations_before_adding_biobank = pytest.negotiator_client.get_all_organizations()
+    cron_job()
+    negotiator_organizations_after_adding_biobank = (
+        pytest.negotiator_client.get_all_organizations()
+    )
+    assert len(negotiator_organizations_after_adding_biobank ) == len(
+        negotiator_organizations_before_adding_biobank) + 1

--- a/tests/integration/integration_tests_single_directory.py
+++ b/tests/integration/integration_tests_single_directory.py
@@ -850,7 +850,7 @@ def test_biobank_sync_when_no_service_added():
         "Biobank with no services",
         "bbmri-eric:contactID:EU_network",
         "false",
-        [],
+        None,
         "insert",
     )
     negotiator_organizations_before_adding_biobank = pytest.negotiator_client.get_all_organizations()

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -218,13 +218,17 @@ def add_or_update_service(
     service_id,
     service_name,
     service_description,
+    biobank_id,
+    directory_version,
     operation=Literal["insert", "update"],
+
 ):
     query = f"mutation {operation}($value:[ServicesInput]){{{operation}(Services:$value){{message}}}}"
     service = {
         "id": service_id,
         "name": service_name,
         "description": service_description,
+        "biobank": {"id": biobank_id},
         "serviceTypes": [
             {
                 "name": "PET-Scans",
@@ -242,6 +246,8 @@ def add_or_update_service(
             "dns": "https://external_server.nl",
         },
     }
+    if directory_version != 'latest':
+        del service['biobank']
     variables = {"value": [service]}
     response = session.post(
         directory_url,

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -20,7 +20,7 @@ def add_or_update_biobank(
     biobank_contact,
     biobank_withdrawn,
     service_id,
-    operation
+    operation: Literal["insert", "update"] = "insert",
 ):
     query = f"mutation {operation}($value:[BiobanksInput]){{{operation}(Biobanks:$value){{message}}}}"
     variables = {
@@ -64,7 +64,7 @@ def add_or_update_collection(
     network,
     collection_contact,
     collection_withdrawn,
-    operation=Literal["insert", "update"],
+    operation: Literal["insert", "update"] = "insert",
     nn_id="NL",
     nn_description="Netherlands",
 ):
@@ -108,7 +108,7 @@ def add_or_update_network(
     network_name,
     network_description,
     contact_id,
-    operation=Literal["insert", "update"],
+    operation: Literal["insert", "update"] = "insert",
 ):
     query = f"mutation {operation}($value:[NetworksInput]){{{operation}(Networks:$value){{message}}}}"
     variables = {
@@ -220,7 +220,7 @@ def add_or_update_service(
     service_description,
     biobank_id,
     directory_version,
-    operation=Literal["insert", "update"],
+    operation: Literal["insert", "update"] = "insert",
 
 ):
     query = f"mutation {operation}($value:[ServicesInput]){{{operation}(Services:$value){{message}}}}"
@@ -261,7 +261,7 @@ def add_or_update_service(
 
 
 def add_or_update_national_node(
-    session, directory_url, nn_id, nn_description, operation=Literal["insert", "update"]
+    session, directory_url, nn_id, nn_description, operation: Literal["insert", "update"] = "insert",
 ):
     query = f"mutation {operation}($value:[NationalNodesInput]){{{operation}(NationalNodes:$value){{message}}}}"
     national_node = {


### PR DESCRIPTION
This CI fixes #28 and rearrange tests in a way to be run twice, having as Directory sources two different emx2 releases: 

 - latest, to ensure that the sync service will remain compatible with new Directory releases; 
 - v11.34.0, old emx2 version set to ensure backward compatibility. This is necessary for sources different than the EU directory, that use older emx2 versions, as eucaim or canserv
